### PR TITLE
Fix mobile header navigation layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -302,18 +302,20 @@ footer a:hover { color: #ffffff; text-decoration: underline; }
 
     /* MOBILE NAVIGATION STYLES */
     header nav {
-        flex-direction: column; /* KEY: Stack navigation items vertically */
+        flex-direction: row; /* Keep navigation horizontal on mobile */
+        flex-wrap: wrap;
+        justify-content: center;
         align-items: center;
         width: 100%;
     }
 
     header nav a {
-        padding: 0.75rem 1rem;
+        padding: 0.6rem 1rem;
         font-size: 1rem;
-        width: 90%;
-        max-width: 320px;
+        width: auto;
+        max-width: none;
         text-align: center;
-        margin: 0.3rem 0;
+        margin: 0.3rem;
         border-radius: 8px;
     }
 


### PR DESCRIPTION
## Summary
- keep header navigation in a horizontal row on mobile devices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864ccd57eac8331aab3372977f72bcc